### PR TITLE
[DX-204] requireSeries

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -233,7 +233,7 @@ var oc = oc || {};
     });
   };
 
-  oc.requireEach = asyncRequireForEach;
+  oc.requireSeries = asyncRequireForEach;
 
   var processHtml = function($component, data, callback) {
     data.id = Math.floor(Math.random() * 9999999999);

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -233,6 +233,8 @@ var oc = oc || {};
     });
   };
 
+  oc.requireEach = asyncRequireForEach;
+
   var processHtml = function($component, data, callback) {
     data.id = Math.floor(Math.random() * 9999999999);
 


### PR DESCRIPTION
At the moment we require externals through the internal `asyncRequireForEach` function only at render time. Exposing that internal function via an `oc.requireSeries` method will allows compiled template to hook on that in case they need for requiring external dependencies when served as SSR (ie: in case of a react hydration scenario)