### PR TITLE
Make sure prettier picks up eslintrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,15 +33,15 @@
   },
   "lint-staged": {
     "src/**/*.js": [
-      "prettier-eslint --write",
+      "prettier-eslint --eslint-config-path ./.eslintrc.json --write",
       "git add"
     ],
     "tasks/*.js": [
-      "prettier-eslint --write",
+      "prettier-eslint --eslint-config-path ./.eslintrc.json --write",
       "git add"
     ],
     "test/*.js": [
-      "prettier-eslint --write",
+      "prettier-eslint --eslint-config-path ./.eslintrc.json --write",
       "git add"
     ]
   },


### PR DESCRIPTION
When trying to create another PR prettier rewrote all `'` to `"`. This PR forces it to use `.eslintrc` which was ignored for some reason.