### PR TITLE
Upgrade jquery to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OC browser client",
   "main": "index.js",
   "repository": {

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -43,7 +43,7 @@ var oc = oc || {};
     IE9_AJAX_POLYFILL_URL =
       CDNJS_BASEURL +
       'jquery-ajaxtransport-xdomainrequest/1.0.3/jquery.xdomainrequest.min.js',
-    JQUERY_URL = CDNJS_BASEURL + 'jquery/1.11.2/jquery.min.js',
+    JQUERY_URL = CDNJS_BASEURL + 'jquery/3.6.0/jquery.min.js',
     RETRY_INTERVAL = oc.conf.retryInterval || 5000,
     RETRY_LIMIT = oc.conf.retryLimit || 30,
     RETRY_SEND_NUMBER = oc.conf.retrySendNumber || true,


### PR DESCRIPTION
Upgrade to the latest version so new functionalities can be used from `oc.$`. The new version is mostly backwards compatible except for some deprecated methods that oc doesn't use, and most of the deprecated methods were gone in version `1.9` anyway, which is prior to the version oc-client-browser has (version `1.11.2`)