### PR TITLE
Render non jquery components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "OC browser client",
   "main": "index.js",
   "repository": {

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -473,9 +473,11 @@ var oc = oc || {};
     });
   };
 
-  oc.renderNestedComponent = function($component, callback) {
+  oc.renderNestedComponent = function(component, callback) {
     oc.ready(function() {
-      var dataRendering = $component.attr('data-rendering'),
+      var $component =
+          typeof component.jquery === 'string' ? component : $.oc(component),
+        dataRendering = $component.attr('data-rendering'),
         dataRendered = $component.attr('data-rendered'),
         isRendering = isBool(dataRendering)
           ? dataRendering

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -476,7 +476,7 @@ var oc = oc || {};
   oc.renderNestedComponent = function(component, callback) {
     oc.ready(function() {
       var $component =
-          typeof component.jquery === 'string' ? component : $.oc(component),
+          typeof component.jquery === 'string' ? component : oc.$(component),
         dataRendering = $component.attr('data-rendering'),
         dataRendered = $component.attr('data-rendered'),
         isRendering = isBool(dataRendering)

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -475,8 +475,7 @@ var oc = oc || {};
 
   oc.renderNestedComponent = function(component, callback) {
     oc.ready(function() {
-      var $component =
-          typeof component.jquery === 'string' ? component : oc.$(component),
+      var $component = oc.$(component),
         dataRendering = $component.attr('data-rendering'),
         dataRendered = $component.attr('data-rendered'),
         isRendering = isBool(dataRendering)

--- a/test/render-nested-component.js
+++ b/test/render-nested-component.js
@@ -14,7 +14,9 @@ describe('oc-client : renderNestedComponent', function() {
     console.log = function() {};
 
     oc.renderByHref = function(href, cb) {
-      htmlBeforeRendering = $component.html();
+      htmlBeforeRendering = $component.jquery
+        ? $component.html()
+        : $component.innerHTML;
       cb(fail, {
         html: '<div>this is the component content</div>',
         version: '1.0.0',
@@ -31,6 +33,20 @@ describe('oc-client : renderNestedComponent', function() {
     oc.renderedComponents = {};
     oc.events.reset();
   };
+
+  describe('when passing a non-jquery html element', function() {
+    var component = document.createElement('oc-component');
+    component.setAttribute('href', componentHref);
+
+    beforeEach(function(done) {
+      initialise(component);
+      oc.renderNestedComponent(component, done);
+    });
+
+    it('should work the same', function() {
+      expect(component.innerHTML).toContain('this is the component content');
+    });
+  });
 
   describe('when rendering component successfully', function() {
     var $component;

--- a/test/render-nested-component.js
+++ b/test/render-nested-component.js
@@ -8,15 +8,13 @@ describe('oc-client : renderNestedComponent', function() {
     componentContainer =
       '<oc-component href="' + componentHref + '"></oc-component>';
 
-  var initialise = function($component, fail) {
+  var initialise = function(component, fail) {
     htmlBeforeRendering = '';
 
     console.log = function() {};
 
     oc.renderByHref = function(href, cb) {
-      htmlBeforeRendering = $component.jquery
-        ? $component.html()
-        : $component.innerHTML;
+      htmlBeforeRendering = $(component).html();
       cb(fail, {
         html: '<div>this is the component content</div>',
         version: '1.0.0',


### PR DESCRIPTION
This allows for oc.renderNestedComponents to be called with normal HTML elements without having to wrap it yourself into a jquery object. This is the first step into being able to remove jQuery as a dependency, which is to allow consumers to not have to use it either. This doesn't break anything, as the current flow works the same.