### PR TITLE
[IMPROVEMENT] Add option to do json requests on getData

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -49,6 +49,7 @@ var oc = oc || {};
     RETRY_SEND_NUMBER = oc.conf.retrySendNumber || true,
     POLLING_INTERVAL = oc.conf.pollingInterval || 500,
     OC_TAG = oc.conf.tag || 'oc-component',
+    JSON_REQUESTS = !!oc.conf.jsonRequests,
     MESSAGES_ERRORS_HREF_MISSING = 'Href parameter missing',
     MESSAGES_ERRORS_RETRY_FAILED =
       'Failed to load {0} component {1} times. Giving up'.replace(
@@ -275,24 +276,30 @@ var oc = oc || {};
     isRequired('version', options.version);
     isRequired('baseUrl', options.baseUrl);
     isRequired('name', options.name);
-
-    oc.$.ajax({
+    var jsonRequest =
+      typeof options.json === 'boolean' ? options.json : JSON_REQUESTS;
+    var data = {
+      components: [
+        {
+          name: options.name,
+          version: options.version,
+          parameters: oc.$.extend(
+            {},
+            oc.conf.globalParameters,
+            options.parameters
+          )
+        }
+      ]
+    };
+    var headers = { Accept: 'application/vnd.oc.unrendered+json' };
+    if (jsonRequest) {
+      headers['Content-Type'] = 'application/json';
+    }
+    var ajaxOptions = {
       method: 'POST',
       url: options.baseUrl,
-      data: {
-        components: [
-          {
-            name: options.name,
-            version: options.version,
-            parameters: oc.$.extend(
-              {},
-              oc.conf.globalParameters,
-              options.parameters
-            )
-          }
-        ]
-      },
-      headers: { Accept: 'application/vnd.oc.unrendered+json' },
+      data: jsonRequest ? JSON.stringify(data) : data,
+      headers: headers,
       crossDomain: true,
       success: function (apiResponse) {
         if (apiResponse[0].response.renderMode === 'rendered') {
@@ -306,7 +313,12 @@ var oc = oc || {};
       error: function (err) {
         return cb(err);
       }
-    });
+    };
+    if (jsonRequest) {
+      ajaxOptions.dataType = 'json';
+    }
+
+    oc.$.ajax(ajaxOptions);
   };
 
   oc.build = function (options) {

--- a/test/get-data.js
+++ b/test/get-data.js
@@ -1,51 +1,51 @@
 'use strict';
 
-describe('oc-client : getData', function() {
-  var execute = function(options, cb) {
+describe('oc-client : getData', function () {
+  var execute = function (options, cb) {
     return oc.getData(options, cb);
   };
 
-  describe('when not providing the mandatory parameters', function() {
-    describe('when asking for data without baseUrl', function() {
-      var throwingFunction = function() {
+  describe('when not providing the mandatory parameters', function () {
+    describe('when asking for data without baseUrl', function () {
+      var throwingFunction = function () {
         return execute({ name: 'someName', version: '0.0.1' });
       };
 
-      it('should throw an error', function() {
+      it('should throw an error', function () {
         expect(throwingFunction).toThrow('baseUrl parameter is required');
       });
     });
 
-    describe('when asking for data without name', function() {
-      var throwingFunction = function() {
+    describe('when asking for data without name', function () {
+      var throwingFunction = function () {
         return execute({
           baseUrl: 'http://www.opencomponents.com',
           version: '0.0.1'
         });
       };
 
-      it('should throw an error', function() {
+      it('should throw an error', function () {
         expect(throwingFunction).toThrow('name parameter is required');
       });
     });
 
-    describe('when asking for data without version', function() {
-      var throwingFunction = function() {
+    describe('when asking for data without version', function () {
+      var throwingFunction = function () {
         return execute({
           baseUrl: 'http://www.opencomponents.com',
           name: 'a-component'
         });
       };
 
-      it('should throw an error', function() {
+      it('should throw an error', function () {
         expect(throwingFunction).toThrow('version parameter is required');
       });
     });
   });
 
-  describe('when providing the mandatory parameters', function() {
-    describe('when requesting data', function() {
-      it('should call the $.ajax method correctly', function(done) {
+  describe('when providing the mandatory parameters', function () {
+    describe('when requesting data', function () {
+      it('should call the $.ajax method correctly', function (done) {
         var spy = sinon.spy(oc.$, 'ajax');
 
         execute(
@@ -57,7 +57,7 @@ describe('oc-client : getData', function() {
               name: 'evil'
             }
           },
-          function() {
+          function () {
             expect(spy.args[0][0].method).toEqual('POST');
             expect(spy.args[0][0].url).toEqual('http://www.components.com/v2');
             expect(spy.args[0][0].data.components[0].name).toEqual(
@@ -70,13 +70,14 @@ describe('oc-client : getData', function() {
             expect(spy.args[0][0].headers.Accept).toEqual(
               'application/vnd.oc.unrendered+json'
             );
+            oc.$.ajax.restore();
             done();
           }
         );
       });
 
-      it('should call the callback correctly', function(done) {
-        oc.$.ajax = function(options) {
+      it('should call the callback correctly', function (done) {
+        oc.$.ajax = function (options) {
           return options.success([
             { response: { renderMode: 'unrendered', data: 'hello' } }
           ]);
@@ -91,7 +92,7 @@ describe('oc-client : getData', function() {
               name: 'evil'
             }
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).toEqual(null);
             expect(data).toEqual('hello');
             done();
@@ -99,8 +100,8 @@ describe('oc-client : getData', function() {
         );
       });
 
-      it('should call the callback with server.js errors details if available', function(done) {
-        oc.$.ajax = function(options) {
+      it('should call the callback with server.js errors details if available', function (done) {
+        oc.$.ajax = function (options) {
           return options.success([
             { response: { error: 'oups', details: 'details about oups' } }
           ]);
@@ -115,15 +116,15 @@ describe('oc-client : getData', function() {
               name: 'evil'
             }
           },
-          function(err) {
+          function (err) {
             expect(err).toEqual('details about oups');
             done();
           }
         );
       });
 
-      it('should call the callback with server.js error if no details are available', function(done) {
-        oc.$.ajax = function(options) {
+      it('should call the callback with server.js error if no details are available', function (done) {
+        oc.$.ajax = function (options) {
           return options.success([{ response: { error: 'oups' } }]);
         };
 
@@ -136,15 +137,15 @@ describe('oc-client : getData', function() {
               name: 'evil'
             }
           },
-          function(err) {
+          function (err) {
             expect(err).toEqual('oups');
             done();
           }
         );
       });
 
-      it('should call the callback with an error if the registry responds with a rendered component', function(done) {
-        oc.$.ajax = function(options) {
+      it('should call the callback with an error if the registry responds with a rendered component', function (done) {
+        oc.$.ajax = function (options) {
           return options.success([
             { response: { renderMode: 'rendered', data: 'hello' } }
           ]);
@@ -159,7 +160,7 @@ describe('oc-client : getData', function() {
               name: 'evil'
             }
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).toEqual('Error getting data');
             expect(data).toEqual(undefined);
             done();
@@ -167,8 +168,37 @@ describe('oc-client : getData', function() {
         );
       });
 
-      describe('when globalParameters are provided', function() {
-        it('should call the $.ajax method with the global parameters', function(done) {
+      describe('when json is requested', function () {
+        it('should call the $.ajax method correctly', function (done) {
+          var spy = sinon.spy(oc.$, 'ajax');
+
+          execute(
+            {
+              baseUrl: 'http://www.components.com/v2',
+              name: 'myComponent',
+              version: '6.6.6',
+              parameters: {
+                name: 'evil'
+              },
+              json: true
+            },
+            function () {
+              expect(spy.args[0][0].data).toEqual(
+                '{"components":[{"name":"myComponent","version":"6.6.6","parameters":{"name":"evil"}}]}'
+              );
+              expect(spy.args[0][0].dataType).toEqual('json');
+              expect(spy.args[0][0].headers['Content-Type']).toEqual(
+                'application/json'
+              );
+              oc.$.ajax.restore();
+              done();
+            }
+          );
+        });
+      });
+
+      describe('when globalParameters are provided', function () {
+        it('should call the $.ajax method with the global parameters', function (done) {
           var spy = sinon.spy(oc.$, 'ajax');
 
           oc.conf.globalParameters = {
@@ -184,7 +214,7 @@ describe('oc-client : getData', function() {
                 name: 'evil'
               }
             },
-            function() {
+            function () {
               expect(spy.args[0][0].data.components[0].parameters.name).toEqual(
                 'evil'
               );


### PR DESCRIPTION
This adds the option to use do `application/json` requests instead of `application/x-www-form-urlencoded` because the latter will convert every value into strings and this is sometimes not desirable. To make this a non-breaking change we will add a new options to set this.

- At the `getData` level, where if you pass {json: true}, it will do a JSON request. This is an optional parameter.
- At the application level by setting `oc.conf.jsonRequests = true`. This will be the global setting used by default, unless overriden by the previous one.