### PR TITLE
add option in conf to add globalheaders to any oc request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -163,6 +163,18 @@ var oc = oc || {};
     return href;
   };
 
+  var getHeaders = function () {
+    var globalHeaders =
+      typeof oc.conf.globalHeaders === 'function'
+        ? oc.conf.globalHeaders()
+        : oc.conf.globalHeaders;
+
+    return oc.$.extend(
+      { Accept: 'application/vnd.oc.unrendered+json' },
+      globalHeaders
+    );
+  };
+
   oc.addStylesToHead = function (styles) {
     oc.$('<style>' + styles + '</style>').appendTo(document.head);
   };
@@ -291,7 +303,7 @@ var oc = oc || {};
         }
       ]
     };
-    var headers = { Accept: 'application/vnd.oc.unrendered+json' };
+    var headers = getHeaders();
     if (jsonRequest) {
       headers['Content-Type'] = 'application/json';
     }
@@ -540,7 +552,7 @@ var oc = oc || {};
 
         oc.$.ajax({
           url: finalisedHref,
-          headers: { Accept: 'application/vnd.oc.unrendered+json' },
+          headers: getHeaders(),
           contentType: 'text/plain',
           crossDomain: true,
           success: function (apiResponse) {

--- a/test/get-data.js
+++ b/test/get-data.js
@@ -222,6 +222,61 @@ describe('oc-client : getData', function () {
                 'value'
               );
               delete oc.conf.globalParameters;
+              oc.$.ajax.restore();
+              done();
+            }
+          );
+        });
+      });
+
+      describe('When global haders are provided', function () {
+        it('should call the $.ajax method with the global headers as data', function (done) {
+          var spy = sinon.spy(oc.$, 'ajax');
+
+          oc.conf.globalHeaders = {
+            testHeader: 'headerValue'
+          };
+
+          execute(
+            {
+              baseUrl: 'http://www.components.com/v2',
+              name: 'myComponent',
+              version: '6.6.6',
+              parameters: {
+                name: 'evil'
+              }
+            },
+            function () {
+              expect(spy.args[0][0].headers.testHeader).toEqual('headerValue');
+              delete oc.conf.globalHeaders;
+              oc.$.ajax.restore();
+              done();
+            }
+          );
+        });
+
+        it('should call the $.ajax method with the global headers as function', function (done) {
+          var spy = sinon.spy(oc.$, 'ajax');
+
+          oc.conf.globalHeaders = function () {
+            return {
+              testHeader: 'headerValue'
+            };
+          };
+
+          execute(
+            {
+              baseUrl: 'http://www.components.com/v2',
+              name: 'myComponent',
+              version: '6.6.6',
+              parameters: {
+                name: 'evil'
+              }
+            },
+            function () {
+              expect(spy.args[0][0].headers.testHeader).toEqual('headerValue');
+              delete oc.conf.globalHeaders;
+              oc.$.ajax.restore();
               done();
             }
           );


### PR DESCRIPTION
This adds a new option in the conf object called `globalHeaders` that behaves similar to `globalParameters`, but for headers. This will allow to set a header to send to all your OCs (useful for authentication, for example). globalHeaders can be an object, or a function that returns an object (in case you want it to depend on globals exposed in window that may change).