### PR TITLE
Remove unused features from l.js

### DIFF
--- a/vendor/l.js
+++ b/vendor/l.js
@@ -32,11 +32,7 @@
     , onreadystatechange = 'onreadystatechange'
     , scriptStr = 'script'
     , header = D[getElementsByTagName]("head")[0] || D.documentElement
-    , aliases = {}
     //-- get the current script tag for further evaluation of it's eventual content
-    , scripts = D[getElementsByTagName](scriptStr)
-    , scriptTag = scripts[scripts[length] - 1]
-    , script = scriptTag.innerHTML.replace(/^\s+|\s+$/g, '')
     , appendElmt = function (type, attrs, cb) {
       var e = D.createElement(type), i;
       if (cb) { //-- this is not intended to be used for link
@@ -58,20 +54,13 @@
     ;
   //avoid multiple inclusion to override current loader but allow tag content evaluation
   if (!window.ljs) {
-    var checkLoaded = scriptTag.src.match(/checkLoaded/) ? 1 : 0
-      //-- keep trace of header as we will make multiple access to it
-      , urlParse = function (url) {
-        var parts = {}; // u => url, i => id, f => fallback, m => is a module
-        parts.u = url.replace(/(^module:)|#(=)?([^#]*)?/g, function (_, m, f, i) { parts[m ? 'm' : f ? 'f' : 'i'] = !!m || i; return ''; });
-        return parts;
-      }
+    //-- keep trace of header as we will make multiple access to it
+    urlParse = function (url) {
+      var parts = {}; // u => url, i => id, f => fallback, m => is a module
+      parts.u = url.replace(/(^module:)|#(=)?([^#]*)?/g, function (_, m, f, i) { parts[m ? 'm' : f ? 'f' : 'i'] = !!m || i; return ''; });
+      return parts;
+    }
       , load = function (loader, url, cb) {
-        if (aliases && aliases[url]) {
-          var args = aliases[url].slice(0);
-          isA(args) || (args = [args]);
-          cb && args.push(cb);
-          return loader.load.apply(loader, args);
-        }
         if (isA(url)) { // parallelized request
           for (var l = url[length]; l--;) {
             loader.load(url[l]);
@@ -87,8 +76,7 @@
       , loaded = {}  // will handle already loaded urls
       , errorHandlers = []
       , loader = {
-        aliases: aliases
-        , loadjs: function (url, cb) {
+        loadjs: function (url, cb) {
           var parts = urlParse(url);
           var onError = function (url) { for (var i = 0, l = errorHandlers.length; i < l; i++) { errorHandlers[i](url) } };
           var type = parts.m ? 'module' : 'text/javascript';
@@ -133,32 +121,14 @@
           load(loader, argv[0], argc <= 1 ? undefined : function () { loader.load.apply(loader, [].slice.call(argv, 1)); });
           return loader;
         }
-        , addAliases: function (_aliases) {
-          for (var i in _aliases) {
-            aliases[i] = isA(_aliases[i]) ? _aliases[i].slice(0) : _aliases[i];
-          }
-          return loader;
-        }
         , onError: function (cb) {
           errorHandlers.push(cb);
           return loader;
         }
       }
       ;
-    if (checkLoaded) {
-      var i, l, links, url;
-      for (i = 0, l = scripts[length]; i < l; i++) {
-        (url = scripts[i].getAttribute('src')) && (loaded[url.replace(/#.*$/, '')] = true);
-      }
-      links = D[getElementsByTagName]('link');
-      for (i = 0, l = links[length]; i < l; i++) {
-        (links[i].rel === 'stylesheet' || links[i].type === 'text/css') && (loaded[links[i].getAttribute('href').replace(/#.*$/, '')] = true);
-      }
-    }
     //export ljs
     window.ljs = loader;
     // eval inside tag code if any
   }
-  // eval script tag content if needed
-  scriptTag.src && script && appendElmt(scriptStr, { innerHTML: script });
 })(window);


### PR DESCRIPTION
l.js has this feature

```html
<script src="l.js?checkLoaded"> // <- adding checkLoaded to the url will dumbly check already inserted script/link tags
	ljs
		.addAliases({
			jQuery:'http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js#jqueryId' // <- script tag will have attribute id=jqueryId
			,ui:[
				'jQuery'
				,'https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js'
				,'myUITheme.css'
			]
		})
		.load('ui',function(){
			/* work with both jquery and jquery-ui here */
		})
	;
</script>
```

Where you can check for l.js already, add aliases and have content already inside the script. But we don't load l.js from a script tag, since we embed it on oc-client-browser, so all these features will not be used. This PRs removes those functionalities so the bundle can go from 9.4Kb to 9.0kb.