### PR TITLE
Fix fail loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -505,6 +505,7 @@ var oc = oc || {};
             $component
               .attr('data-rendering', 'false')
               .attr('data-rendered', 'false')
+              .attr('data-failed', 'true')
               .html('');
             oc.events.fire('oc:failed', {
               originalError: err,
@@ -614,7 +615,9 @@ var oc = oc || {};
 
   oc.renderUnloadedComponents = function () {
     oc.ready(function () {
-      var $unloadedComponents = oc.$(OC_TAG + '[data-rendered!=true]'),
+      var $unloadedComponents = oc.$(
+          OC_TAG + '[data-rendered!=true][data-failed!=true]'
+        ),
         toDo = $unloadedComponents.length;
 
       var done = function () {

--- a/test/render-nested-component.js
+++ b/test/render-nested-component.js
@@ -95,6 +95,10 @@ describe('oc-client : renderNestedComponent', function () {
       expect($component.attr('data-rendered')).toBe('false');
     });
 
+    it('should set fail meta to true', function () {
+      expect($component.attr('data-failed')).toBe('true');
+    });
+
     it('should fire a failed event', function () {
       expect(failedEvent).toBeDefined();
       expect(failedEvent.component).toBe($component[0]);

--- a/test/render-unloaded-components.js
+++ b/test/render-unloaded-components.js
@@ -54,10 +54,13 @@ describe('oc-client : renderUnloadedComponents', function () {
       anotherComponentHtml =
         '<oc-component href="' +
         anotherComponent.response.href +
-        '"></oc-component>';
+        '"></oc-component>',
+      failedComponent =
+        '<oc-component href="" data-failed="true"></oc-component>';
 
     oc.$('body').append(aComponentHtml);
     oc.$('body').append(anotherComponentHtml);
+    oc.$('body').append(failedComponent);
     eval(aComponent.view);
     eval(anotherComponent.view);
   };
@@ -92,7 +95,7 @@ describe('oc-client : renderUnloadedComponents', function () {
 
       afterEach(cleanup);
 
-      it('should fire an event for each rendered component', function () {
+      it('should fire an event for each rendered component and ignore the failed one', function () {
         expect(eventData.length).toEqual(2);
       });
 


### PR DESCRIPTION
Adding a "data-failed" attribute when the retries are exhausted, so it doesn't enter into a crashing loop.

The problem now is that renderUnloadedComponents will call itself once it finishes (in case some ocs spawn more ocs on the html), and this means that the retry limit won't be respected. So it will enter into a loop of calling the registry (without even respecting the retry interval). So what happens is that if a request for a component doesn't exist, the client could DDos the registry by flooding it with requests that return 404.

This adds an attribute, so even in recursion conditions, once a component has been retried, it's never retried again.