### PR TITLE
add compile sync function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,9 @@ declare const ocClient: {
   compile: {
     (options?: CompileOptions): Promise<Compiled>;
   };
+  compileSync: {
+    (options?: CompileOptions): Compiled;
+  };
   getLib: {
     (cb: Callback<string>): void;
     (): Promise<string>;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const { fromCallback, fromPromise } = require('universalify');
-const compile = require('./tasks/compile');
+const { compile, compileSync } = require('./tasks/compile');
 
 const distDir = 'dist';
 const clientLibFileName = 'oc-client.min.js';
@@ -27,6 +27,7 @@ function getMap(cb) {
 
 module.exports = {
   compile: fromPromise(compile),
+  compileSync,
   getLib: fromCallback(getLib),
   getMap: fromCallback(getMap),
   version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const compile = require('./compile');
+const { compile } = require('./compile');
 
 async function build() {
   const distPath = '../dist/';


### PR DESCRIPTION
This exports a new `compileSync` function that does the same thing as `compile` but in a sync fashion. Useful in situations where you want to serve a compiled version on the server and compile right when starting the server, so you don't have to wrap it in functions and have it as modular constant to use later.