### PR TITLE
BUGFIX: Use `module.exports` instead of `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -85,5 +85,7 @@ function compileSync(conf = {}) {
   return compileFiles(l, ocClient);
 }
 
-exports.compile = compile;
-exports.compileSync = compileSync;
+module.exports = {
+  compile: compile,
+  compileSync: compileSync,
+};


### PR DESCRIPTION
# Description

## Problem

Ever since [v1.6.5](https://github.com/opencomponents/oc-client-browser/commit/4dd1724e9196975cb085b776470791f4f03de14c#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3) was released we have been running into import exceptions for `oc-client`:

> _* oc-client: Component execution error: exports is not defined (500)_

It looks like the cause of this is the choice of `exports` over `module.exports` **[here](https://github.com/opencomponents/oc-client-browser/commit/4dd1724e9196975cb085b776470791f4f03de14c#diff-419bad3ed50dc1ffe5761b94a7015fc1f4eae0d295f217e3719cfc6c893907e0R88-R89)**.

## Solution

We should prefer `module.exports` over `exports`