### PR TITLE
include raw element on oc:rendered event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-client-browser",
-  "version": "1.5.9",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-client-browser",
-      "version": "1.5.9",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "uglify-js": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -262,6 +262,8 @@ var oc = oc || {};
       if (data.baseUrl) {
         oc.renderedComponents[data.name].baseUrl = data.baseUrl;
       }
+      // Get raw element from jQuery object
+      data.element = $component[0];
       oc.events.fire('oc:rendered', data);
     }
 

--- a/test/render-unloaded-components.js
+++ b/test/render-unloaded-components.js
@@ -105,6 +105,13 @@ describe('oc-client : renderUnloadedComponents', function () {
         expect(eventData[1].name).toEqual('another-component');
         expect(eventData[1].version).toEqual('1.0.0');
       });
+
+      it('should include the raw html elements on the event payload', function () {
+        expect(eventData[0].element.innerHTML).toEqual('Hello world!');
+        expect(eventData[1].element.innerHTML).toEqual(
+          '<div>this is a component</div>'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
This includes the raw element as part of the data event, which is useful in some scenarios to have. The id is part of the event, but depending on circumstances the id might not be there anymore, and that would mean that trying to find the element is not possible anymore.