### PR TITLE
Stop retrying on 429

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -630,7 +630,9 @@ var oc = oc || {};
               });
             }
           },
-          error: function () {
+          error: function (error) {
+            var status = error && error.status;
+            if (status === 429) retries[href] = 0;
             logger.error(MESSAGES_ERRORS_RETRIEVING);
             retry(
               href,


### PR DESCRIPTION
This adds logic for the client to not retry a failed component if the component explicitly returns a status of 429.
