### PR TITLE
Add externals

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,30 @@
 type Callback<T> = (err: NodeJS.ErrnoException | null, data: T) => void;
 
+interface External {
+  global: string | string[];
+  url: string;
+}
+interface ExtendedExternal extends External {
+  name: string;
+  devUrl?: string;
+}
+
 interface TemplateRenderer {
   getInfo: () => {
-    externals: Array<{
-      name: string;
-      global: string | string[];
-      url: string;
-      devUrl?: string;
-    }>;
+    externals: ExtendedExternal[];
     type: string;
     version: string;
   };
 }
 
 type Template = {
-  externals: Array<{ global: string | string[]; url: string }>;
+  externals: External[];
 };
 interface CompileOptions {
   templates?: Record<string, Template> | TemplateRenderer[];
   retryInterval?: number;
   retryLimit?: number;
-  /**
-   * JavaScript as a string code to be executed before rendering the templates
-   */
-  beforeRender?: string;
+  externals?: External[];
 }
 type Compiled = { code: string; map: string; dev: string };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -1,4 +1,4 @@
-/* globals define, exports, require, globalThis, __REGISTERED_TEMPLATES_PLACEHOLDER__, __DEFAULT_RETRY_INTERVAL__, __DEFAULT_RETRY_LIMIT__, __BEFORE_RENDER__ */
+/* globals define, exports, require, globalThis, __REGISTERED_TEMPLATES_PLACEHOLDER__, __DEFAULT_RETRY_INTERVAL__, __DEFAULT_RETRY_LIMIT__, __EXTERNALS__ */
 /* eslint no-var: 'off' */
 /* eslint prefer-arrow-callback: 'off' */
 
@@ -100,7 +100,8 @@ var oc = oc || {};
     }
   };
 
-  var registeredTemplates = __REGISTERED_TEMPLATES_PLACEHOLDER__;
+  var registeredTemplates = __REGISTERED_TEMPLATES_PLACEHOLDER__,
+    externals = __EXTERNALS__;
 
   function registerTemplates(templates, overwrite) {
     templates = Array.isArray(templates) ? templates : [templates];
@@ -690,11 +691,12 @@ var oc = oc || {};
       }
     });
   };
-
-  __BEFORE_RENDER__;
-
   // render the components
-  oc.ready(oc.renderUnloadedComponents);
+  oc.ready(function () {
+    oc.requireSeries(externals, function () {
+      oc.renderUnloadedComponents();
+    });
+  });
 
   // expose public variables and methods
   exports = oc;

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -64,7 +64,7 @@ function getFiles({ sync = false, conf = {} }) {
         '__REGISTERED_TEMPLATES_PLACEHOLDER__',
         JSON.stringify(registeredTemplates)
       )
-      .replaceAll('__BEFORE_RENDER__', conf.beforeRender || '')
+      .replaceAll('__EXTERNALS__', conf.externals || '[]')
       .replaceAll('__DEFAULT_RETRY_LIMIT__', conf.retryLimit || 30)
       .replaceAll('__DEFAULT_RETRY_INTERVAL__', conf.retryInterval || 5000);
 


### PR DESCRIPTION
The previous beforeRender was probably too powerful and added unnecessary footguns, so I'm adding a safer "externals" property, following the schema for templates, for adding globals that are not attached to templates per se, but might be useful all around for your oc system (logging libraries and so on).