### PR TITLE
add option to disable loader

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ interface CompileOptions {
   templates?: Record<string, Template> | TemplateRenderer[];
   retryInterval?: number;
   retryLimit?: number;
+  disableLoader?: boolean;
   externals?: External[];
 }
 type Compiled = { code: string; map: string; dev: string };

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -1,4 +1,4 @@
-/* globals define, exports, require, globalThis, __REGISTERED_TEMPLATES_PLACEHOLDER__, __DEFAULT_RETRY_INTERVAL__, __DEFAULT_RETRY_LIMIT__, __EXTERNALS__ */
+/* globals define, exports, require, globalThis, __REGISTERED_TEMPLATES_PLACEHOLDER__, __DEFAULT_RETRY_INTERVAL__, __DEFAULT_RETRY_LIMIT__, __DEFAULT_DISABLE_LOADER__, __EXTERNALS__ */
 /* eslint no-var: 'off' */
 /* eslint prefer-arrow-callback: 'off' */
 
@@ -46,6 +46,10 @@ var oc = oc || {};
     JQUERY_URL = CDNJS_BASEURL + 'jquery/3.6.0/jquery.min.js',
     RETRY_INTERVAL = oc.conf.retryInterval || __DEFAULT_RETRY_INTERVAL__,
     RETRY_LIMIT = oc.conf.retryLimit || __DEFAULT_RETRY_LIMIT__,
+    DISABLE_LOADER =
+      typeof oc.conf.disableLoader === 'boolean'
+        ? oc.conf.disableLoader
+        : __DEFAULT_DISABLE_LOADER__,
     RETRY_SEND_NUMBER = oc.conf.retrySendNumber || true,
     POLLING_INTERVAL = oc.conf.pollingInterval || 500,
     OC_TAG = oc.conf.tag || 'oc-component',
@@ -533,9 +537,11 @@ var oc = oc || {};
       if (!isRendering && !isRendered) {
         logger.info(MESSAGES_RETRIEVING);
         $component.attr('data-rendering', true);
-        $component.html(
-          '<div class="oc-loading">' + MESSAGES_LOADING_COMPONENT + '</div>'
-        );
+        if (!DISABLE_LOADER) {
+          $component.html(
+            '<div class="oc-loading">' + MESSAGES_LOADING_COMPONENT + '</div>'
+          );
+        }
 
         oc.renderByHref($component.attr('href'), function (err, data) {
           if (err || !data) {

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -66,7 +66,8 @@ function getFiles({ sync = false, conf = {} }) {
       )
       .replaceAll('__EXTERNALS__', JSON.stringify(conf.externals || []))
       .replaceAll('__DEFAULT_RETRY_LIMIT__', conf.retryLimit || 30)
-      .replaceAll('__DEFAULT_RETRY_INTERVAL__', conf.retryInterval || 5000);
+      .replaceAll('__DEFAULT_RETRY_INTERVAL__', conf.retryInterval || 5000)
+      .replaceAll('__DEFAULT_DISABLE_LOADER__', conf.disableLoader ?? false);
 
   if (sync) {
     const l = fs.readFileSync(lPath, 'utf-8');


### PR DESCRIPTION
Add an option to disable the loader so if you have something like

<oc-component href="">
  My custom placeholder
</oc-component>

Your placeholder will remain in place instead of being replaced by the empty div with a loader.