### PR TITLE
remove logic of api returning a "rendered" response as it can't happen

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -83,7 +83,6 @@ var oc = oc || {};
     MESSAGES_ERRORS_RETRY_FAILED =
       'Failed to load $0 component ' + RETRY_LIMIT + ' times. Giving up',
     MESSAGES_ERRORS_LOADING_COMPILED_VIEW = 'Error getting compiled view: $0',
-    MESSAGES_ERRORS_GETTING_DATA = 'Error getting data',
     MESSAGES_ERRORS_RENDERING = 'Error rendering component: $1, error: $0',
     MESSAGES_ERRORS_RETRIEVING =
       'Failed to retrieve the component. Retrying in ' +
@@ -277,9 +276,6 @@ var oc = oc || {};
       crossDomain: true,
       success: function (apiResponse) {
         var response = apiResponse[0].response;
-        if (response.renderMode == 'rendered') {
-          return cb(MESSAGES_ERRORS_GETTING_DATA);
-        }
         var err = response.error ? response.details || response.error : null;
         cb(err, response.data, apiResponse[0]);
       },
@@ -530,49 +526,24 @@ var oc = oc || {};
           crossDomain: true,
           success: function (apiResponse) {
             var template = apiResponse.template;
-            if (apiResponse.renderMode == 'unrendered') {
-              apiResponse.data.id = id;
-              oc.render(template, apiResponse.data, function (err, html) {
-                if (err) {
-                  callback(
-                    interpolate(
-                      MESSAGES_ERRORS_RENDERING,
-                      err,
-                      apiResponse.href
-                    )
-                  );
-                } else {
-                  logInfo(interpolate(MESSAGES_RENDERED, template.src));
-                  callback(null, {
-                    id: id,
-                    html: html,
-                    baseUrl: apiResponse.baseUrl,
-                    key: template.key,
-                    version: apiResponse.version,
-                    name: apiResponse.name
-                  });
-                }
-              });
-            } else if (apiResponse.renderMode == 'rendered') {
-              logInfo(interpolate(MESSAGES_RENDERED, apiResponse.href));
-
-              if (apiResponse.html.indexOf('<' + OC_TAG) == 0) {
-                var innerHtmlPlusEnding = apiResponse.html.slice(
-                    apiResponse.html.indexOf('>') + 1
-                  ),
-                  innerHtml = innerHtmlPlusEnding.slice(
-                    0,
-                    innerHtmlPlusEnding.lastIndexOf('<')
-                  );
-
-                apiResponse.html = innerHtml;
+            apiResponse.data.id = id;
+            oc.render(template, apiResponse.data, function (err, html) {
+              if (err) {
+                callback(
+                  interpolate(MESSAGES_ERRORS_RENDERING, err, apiResponse.href)
+                );
+              } else {
+                logInfo(interpolate(MESSAGES_RENDERED, template.src));
+                callback(null, {
+                  id: id,
+                  html: html,
+                  baseUrl: apiResponse.baseUrl,
+                  key: template.key,
+                  version: apiResponse.version,
+                  name: apiResponse.name
+                });
               }
-              callback(null, {
-                html: apiResponse.html,
-                version: apiResponse.version,
-                name: apiResponse.name
-              });
-            }
+            });
           },
           error: function (err) {
             if (err && err.status == 429) {

--- a/test/get-data.js
+++ b/test/get-data.js
@@ -148,30 +148,6 @@ describe('oc-client : getData', function () {
         );
       });
 
-      it('should call the callback with an error if the registry responds with a rendered component', function (done) {
-        oc.$.ajax = function (options) {
-          return options.success([
-            { response: { renderMode: 'rendered', data: 'hello' } }
-          ]);
-        };
-
-        execute(
-          {
-            baseUrl: 'http://www.components.com/v2',
-            name: 'myComponent',
-            version: '6.6.6',
-            parameters: {
-              name: 'evil'
-            }
-          },
-          function (err, data) {
-            expect(err).toEqual('Error getting data');
-            expect(data).toEqual(undefined);
-            done();
-          }
-        );
-      });
-
       describe('when json is requested', function () {
         it('should call the $.ajax method correctly', function (done) {
           var spy = sinon.spy(oc.$, 'ajax');

--- a/test/render-by-href.js
+++ b/test/render-by-href.js
@@ -158,54 +158,6 @@ describe('oc-client : renderByHref', function () {
         });
       });
 
-      describe('when the registry responds with rendered component with container', function () {
-        var callback;
-        beforeEach(function () {
-          callback = sinon.spy();
-          initialise(renderedResponse);
-          eval(compiledViewContent);
-          oc.renderByHref(route, callback);
-        });
-
-        afterEach(cleanup);
-
-        it('should respond without an error', function () {
-          expect(callback.args[0][0]).toBe(null);
-        });
-
-        it('should respond with the rendered html', function () {
-          expect(callback.args[0][1].html).toEqual('Hello, world!!!');
-        });
-
-        it('should respond with the correct version', function () {
-          expect(callback.args[0][1].version).toEqual('1.2.123');
-        });
-      });
-
-      describe('when the registry responds with rendered component without container', function () {
-        var callback;
-        beforeEach(function () {
-          callback = sinon.spy();
-          initialise(renderedNoContainerResponse);
-          eval(compiledViewContent);
-          oc.renderByHref(route, callback);
-        });
-
-        afterEach(cleanup);
-
-        it('should respond without an error', function () {
-          expect(callback.args[0][0]).toBe(null);
-        });
-
-        it('should respond with the rendered html', function () {
-          expect(callback.args[0][1].html).toEqual('Hello, world!!');
-        });
-
-        it('should respond with the correct version', function () {
-          expect(callback.args[0][1].version).toEqual('1.2.123');
-        });
-      });
-
       describe('when getting component returns an error', function () {
         var ajaxMock, error;
         beforeEach(function (done) {


### PR DESCRIPTION
I'm looking at the logic, and for both calls (render and getData), we use the getHeaders function that always add the header `Accept: 'application/vnd.oc.unrendered+json'` to the request.

When that happens, the response is always going to be unrendered, with one single exception, which is when oc-client-node calls the endpoint and the template is not supported ([see here](https://github.com/opencomponents/oc/blob/8450ccee2419fb9f0732d2fa0ae053dffeece754/src/registry/routes/helpers/get-component.ts#L286)). This can only happen with node, where the node client will send a specific oc-client user agent string, so I don't see how it can ever happen in a browser context.

I got to think that some time ago this code was somehow moved from server to client and found it's way there, but I think is 100% safe to remove.