### PR TITLE
remove dataType

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -273,7 +273,6 @@ var oc = oc || {};
       error: cb
     };
     if (jsonRequest) {
-      ajaxOptions.dataType = 'json';
       headers['Content-Type'] = 'application/json';
     }
 


### PR DESCRIPTION
Remove dataType attribute, since it's not needed (it helps jquery convert to json if the server doesn't reply with the correct content-Type, but oc responds correctly), and creates a bug if parameters have double question mark as stated in their docs

> In requests with dataType: "json" or dataType: "jsonp", if the string contains a double question mark (??) anywhere in the URL or a single question mark (?) in the query string, it is replaced with a value generated by jQuery that is unique for each copy of the library on the page (e.g. jQuery21406515378922229067_1479880736745).