### PR TITLE
allow empty action calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-client-browser",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "OC browser client",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -297,13 +297,17 @@ var oc = oc || {};
           if (err) {
             reject(err);
           } else {
-            var props = data.component.props;
-            delete props._staticPath;
-            delete props._baseUrl;
-            delete props._componentName;
-            delete props._componentVersion;
+            if (data.component) {
+              var props = data.component.props;
+              delete props._staticPath;
+              delete props._baseUrl;
+              delete props._componentName;
+              delete props._componentVersion;
 
-            resolve(props);
+              resolve(props);
+            } else {
+              resolve();
+            }
           }
         }
       );


### PR DESCRIPTION
allow empty action calls by not throwing when checking for component.props if its returning an empty response