### PR TITLE
fix nested polling

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -518,41 +518,48 @@ export function createOc(oc) {
 			let isRendering = dataRendering == "true";
 			let isRendered = dataRendered == "true";
 
-			if (!isRendering && !isRendered) {
-				logInfo(MESSAGES_RETRIEVING);
-				setAttribute(dataRenderingAttribute, true);
-				if (!DISABLE_LOADER) {
-					component.innerHTML =
-						'<div class="oc-loading">' + MESSAGES_LOADING_COMPONENT + "</div>";
-				}
-
-				oc.renderByHref(
-					{
-						href: getAttribute("href"),
-						id: getAttribute("id"),
-						element: component,
-					},
-					(err, data) => {
-						if (err || !data) {
-							setAttribute(dataRenderingAttribute, false);
-							setAttribute(dataRenderedAttribute, false);
-							setAttribute("data-failed", true);
-							component.innerHTML = "";
-							oc.events.fire("oc:failed", {
-								originalError: err,
-								data: data,
-								component,
-							});
-							logError(err);
-							callback();
-						} else {
-							processHtml(component, data, callback);
-						}
-					},
-				);
-			} else {
-				timeout(callback, POLLING_INTERVAL);
+			if (isRendered) {
+				callback();
+				return;
 			}
+			if (isRendering) {
+				timeout(() => {
+					oc.renderNestedComponent(component, callback);
+				}, POLLING_INTERVAL);
+				return;
+			}
+
+			logInfo(MESSAGES_RETRIEVING);
+			setAttribute(dataRenderingAttribute, true);
+			if (!DISABLE_LOADER) {
+				component.innerHTML =
+					'<div class="oc-loading">' + MESSAGES_LOADING_COMPONENT + "</div>";
+			}
+
+			oc.renderByHref(
+				{
+					href: getAttribute("href"),
+					id: getAttribute("id"),
+					element: component,
+				},
+				(err, data) => {
+					if (err || !data) {
+						setAttribute(dataRenderingAttribute, false);
+						setAttribute(dataRenderedAttribute, false);
+						setAttribute("data-failed", true);
+						component.innerHTML = "";
+						oc.events.fire("oc:failed", {
+							originalError: err,
+							data: data,
+							component,
+						});
+						logError(err);
+						callback();
+					} else {
+						processHtml(component, data, callback);
+					}
+				},
+			);
 		});
 	};
 

--- a/tests/edgeCases.spec.js
+++ b/tests/edgeCases.spec.js
@@ -169,7 +169,7 @@ test.describe("oc-client : edge cases", () => {
 		});
 
 		expect(result.callbackCalled).toBe(true);
-		expect(result.wasDelayed).toBe(true);
+		expect(result.wasDelayed).toBe(false);
 	});
 
 	test("should handle renderNestedComponent with currently rendering component", async ({
@@ -195,6 +195,11 @@ test.describe("oc-client : edge cases", () => {
 						wasDelayed: endTime - startTime >= 400,
 					});
 				});
+
+				setTimeout(() => {
+					element.setAttribute("data-rendering", "false");
+					element.setAttribute("data-rendered", "true");
+				}, 200);
 			});
 		});
 


### PR DESCRIPTION
This change refactors the polling logic in renderNestedComponent to fix race conditions and remove unnecessary delays.

### Previous Behavior
The old implementation had two issues:
It added a polling delay even when a component was already rendered.
When a component was currently rendering, it would wait for one polling cycle and then stop checking. This caused rendering to fail if the component took longer to load than the polling interval.

### New Behavior
The logic now explicitly handles three distinct states:
If rendered: The callback is invoked immediately.
If rendering: The function polls by recursively calling itself until rendering is complete.
If not rendered: It initiates the rendering process as before.
This new approach ensures that nested components reliably complete their rendering cycle, fixing bugs related to concurrent rendering requests.