### PR TITLE
Automatic management of lifecycles if supported

### DIFF
--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -679,20 +679,23 @@ export function createOc(oc) {
 			class extends HTMLElement {
 				#connected = false;
 				#manageLifecycle = !DISABLE_LIFECYCLES;
+				// biome-ignore lint/complexity/noUselessConstructor: <explanation>
 				constructor() {
 					super();
-					if (
-						this.getAttribute("disable-lifecycle") == "true" ||
-						this.getAttribute("disable-lifecycle") == ""
-					) {
-						this.#manageLifecycle = true;
-					} else if (this.getAttribute("disable-lifecycle") == "false") {
-						this.#manageLifecycle = false;
-					}
 				}
 
 				connectedCallback() {
 					this.#connected = true;
+
+					if (
+						this.getAttribute("disable-lifecycle") == "true" ||
+						this.getAttribute("disable-lifecycle") == ""
+					) {
+						this.#manageLifecycle = false;
+					} else if (this.getAttribute("disable-lifecycle") == "false") {
+						this.#manageLifecycle = true;
+					}
+
 					if (this.#manageLifecycle) {
 						oc.renderNestedComponent(this, () => {});
 					}

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -52,8 +52,8 @@ export function createOc(oc) {
 	let RETRY_SEND_NUMBER = ocConf.retrySendNumber || true;
 	let POLLING_INTERVAL = ocConf.pollingInterval || 500;
 	let OC_TAG = ocConf.tag || "oc-component";
-	let MANAGE_LIFECYCLES = isBool(ocConf.manageLifecycles)
-		? ocConf.manageLifecycles
+	let DISABLE_LIFECYCLES = isBool(ocConf.disableLifecycles)
+		? ocConf.disableLifecycles
 		: false;
 	let MESSAGES_ERRORS_HREF_MISSING = "Href parameter missing";
 	let MESSAGES_ERRORS_RETRY_FAILED =
@@ -678,15 +678,16 @@ export function createOc(oc) {
 			OC_TAG,
 			class extends HTMLElement {
 				#connected = false;
-				#manageLifecycle = false;
+				#manageLifecycle = !DISABLE_LIFECYCLES;
 				constructor() {
 					super();
 					if (
-						MANAGE_LIFECYCLES ||
-						this.getAttribute("manage-lifecycle") == "true" ||
-						this.getAttribute("manage-lifecycle") == ""
+						this.getAttribute("disable-lifecycle") == "true" ||
+						this.getAttribute("disable-lifecycle") == ""
 					) {
 						this.#manageLifecycle = true;
+					} else if (this.getAttribute("disable-lifecycle") == "false") {
+						this.#manageLifecycle = false;
 					}
 				}
 


### PR DESCRIPTION
This change introduces support for Custom Elements, allowing oc-component elements to automatically manage their own lifecycle, including rendering and unmounting.

### Previous Behavior
Previously, oc-component tags were inert placeholders. Developers had to manually scan the DOM and call oc.render or oc.renderNestedComponent to render them if components we added after the client loaded. There was no built-in mechanism for cleanup or unmounting when a component was removed from the DOM.

### New Behavior

This PR defines a custom element for the oc-component tag.
Automatic Rendering: When an <oc-component> with the manage-lifecycle attribute is added to the DOM, its connectedCallback is triggered, which automatically calls oc.renderNestedComponent on itself.
Automatic Unmounting: If the component was rendered and has an unmount function (templates will start adding the unmount function on the element), its disconnectedCallback will execute the unmount function when the element is removed from the DOM.
This feature is opt-in and can be enabled globally via the manageLifecycles configuration or on a per-component basis by adding the manage-lifecycle attribute. This automates the component lifecycle, simplifying the integration of components in modern front-end frameworks.