### PR TITLE
pass development context if exists to esm renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "oc-client-browser",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"description": "OC browser client",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -457,7 +457,10 @@ export function createOc(oc) {
 			};
 
 			const { mount } = await import(data.component.src);
-			mount(data.element, data.component.props);
+			let context = {};
+			if (data.component.development)
+				context.development = data.component.development;
+			mount(data.element, data.component.props, context);
 			callback(null);
 		} catch (error) {
 			console.error("Error rendering ESM component", error);


### PR DESCRIPTION
Useful for esm components in dev. this context object might get amplified later with things like ssr, and so on