### PR TITLE
Allow passign an AbortSignal to getData/getAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "oc-client-browser",
-	"version": "2.1.9",
+	"version": "2.1.10",
 	"description": "OC browser client",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/src/oc-client.js
+++ b/src/oc-client.js
@@ -284,6 +284,7 @@ export function createOc(oc) {
 			method: "POST",
 			headers: headers,
 			body: JSON.stringify(data),
+			signal: options.signal,
 		})
 			.then(handleFetchResponse)
 			.then((apiResponse) => {


### PR DESCRIPTION
So frameworks can control the fetch data logic when using serverClient on vite templates